### PR TITLE
Resolve RemovedInDjango19Warning

### DIFF
--- a/lumberjack/models.py
+++ b/lumberjack/models.py
@@ -5,9 +5,14 @@ class LogEntry(models.Model):
     level       = models.CharField(max_length=16)
     message     = models.TextField()
     logged_at   = models.DateTimeField(auto_now_add=True)
+    
+    class Meta:
+        app_label = 'lumberjack'
 
 
 class LogTag(models.Model):
     tag         = models.CharField(max_length=64)
     log_entries = models.ManyToManyField(LogEntry, related_name='tags')
-
+    
+    class Meta:
+        app_label = 'lumberjack'


### PR DESCRIPTION
RemovedInDjango19Warning: Model class lumberjack.models.LogEntry doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.

RemovedInDjango19Warning: Model class lumberjack.models.LogTag doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.

Since the logging is loaded early, it throws this warning although lumberjack is in the `INSTALLED_APPS`.
