### PR TITLE
Fixed 'Log tag' in Django Admin from showing lumberjack.LogTag.None in Django 1.8+

### DIFF
--- a/lumberjack/admin.py
+++ b/lumberjack/admin.py
@@ -1,18 +1,19 @@
 from django.contrib import admin
-from .models import LogEntry
+from .models import LogEntry, LogTag
 
+
+@admin.register(LogEntry)
 class LogEntryAdmin(admin.ModelAdmin):
-    list_display = ('message', 'level', 'logged_at', 'tags')
-    readonly_fields = ('level', 'message', 'logged_at', 'tags')
+    list_display = ('message', 'level', 'logged_at', 'tags_display')
+    readonly_fields = ('level', 'message', 'logged_at', 'tags_display')
     list_filter = ('level', )
     search_fields = ('message', 'tags__tag')
 
-    def tags(self, obj):
-        tags = ''
-        for t in obj.tags.all():
-            tags += '{}, '.format(t.tag)
+    def get_queryset(self, request):
+        return super(LogEntryAdmin, self).get_queryset(
+            request
+        ).prefetch_related('tags')
 
-        return tags[:-2]
-
-admin.site.register(LogEntry, LogEntryAdmin)
-
+    def tags_display(self, obj):
+        return ', '.join(map(str, obj.tags.all()))
+    tags_display.short_description = 'Tags'

--- a/lumberjack/models.py
+++ b/lumberjack/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 
 class LogEntry(models.Model):
@@ -10,9 +11,13 @@ class LogEntry(models.Model):
         app_label = 'lumberjack'
 
 
+@python_2_unicode_compatible
 class LogTag(models.Model):
     tag         = models.CharField(max_length=64)
     log_entries = models.ManyToManyField(LogEntry, related_name='tags')
     
     class Meta:
         app_label = 'lumberjack'
+
+    def __str__(self):
+        return self.tag


### PR DESCRIPTION
After @michaeljohnbarr and I updated CPD to Django 1.8, we noticed that the 'Log tag' column in the Django Admin always showed lumberjack.LogTag.None.  This pull request should fix this issue and still be compatible with Django 1.7.