### PR TITLE
Update handlers.py

### DIFF
--- a/lumberjack/handlers.py
+++ b/lumberjack/handlers.py
@@ -1,14 +1,13 @@
 from logging import Handler
-from .models import LogEntry, LogTag
+
 
 class DBHandler(Handler, object):
 
     def emit(self, record):
-
+        from .models import LogEntry, LogTag
         log_entry = LogEntry.objects.create(level=record.levelname, message=record.msg)
 
         if record.args:
             for tag in record.args[0]:
                 log_tag = LogTag.objects.get_or_create(tag=tag)
                 log_tag[0].log_entries.add(log_entry)
-


### PR DESCRIPTION
In Django 1.9+, without moving the import of the model into the `emit()` method, you get the `django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet` message due to the logging trying to initialize the model prior to the AppRegistry knowing about the model.